### PR TITLE
Minimal check against duplicate ISRC on register

### DIFF
--- a/src/app/database/database.component.ts
+++ b/src/app/database/database.component.ts
@@ -71,7 +71,7 @@ export class DatabaseComponent extends InputsComponent implements OnInit {
     added$.subscribe(
       (recordings) => {
         this.snackBar.open('Recording registered. Showing all entries.', 'OK', {duration: SNACK_DELAY});
-        this.currRecordings = recordings;
+        this.reset();
       },
       (error) => {
         this.snackBar.open('There has been an error. The recording was not registered.', 'OK');
@@ -100,7 +100,7 @@ export class DatabaseComponent extends InputsComponent implements OnInit {
   }
 
   /**
-   * Resets the state of the component, rendering the full list of database recordings.
+   * Resets the state of the list, rendering all of the database recordings.
    */
   reset() {
     this.currRecordings = this.recordings;

--- a/src/app/shared/confirm-dialogue/confirm-dialogue.component.html
+++ b/src/app/shared/confirm-dialogue/confirm-dialogue.component.html
@@ -1,0 +1,11 @@
+<h1 mat-dialog-title>{{ data.title }}</h1>
+<div mat-dialog-content>
+    <p [innerHTML]="data.body"></p>
+</div>
+<div mat-dialog-actions>
+    <button mat-button
+      [mat-dialog-close]="false">Cancel</button>
+    <button mat-flat-button color="accent"
+      cdkFocusInitial
+      [mat-dialog-close]="true">{{ data.action }}</button>
+</div>

--- a/src/app/shared/confirm-dialogue/confirm-dialogue.component.scss
+++ b/src/app/shared/confirm-dialogue/confirm-dialogue.component.scss
@@ -1,0 +1,10 @@
+.mat-dialog-title {
+  color: var(--accent);
+}
+.mat-dialog-content {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+.mat-dialog-actions {
+  justify-content: flex-end;
+}

--- a/src/app/shared/confirm-dialogue/confirm-dialogue.component.spec.ts
+++ b/src/app/shared/confirm-dialogue/confirm-dialogue.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmDialogueComponent } from './confirm-dialogue.component';
+
+describe('ConfirmDialogueComponent', () => {
+  let component: ConfirmDialogueComponent;
+  let fixture: ComponentFixture<ConfirmDialogueComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ConfirmDialogueComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmDialogueComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/confirm-dialogue/confirm-dialogue.component.ts
+++ b/src/app/shared/confirm-dialogue/confirm-dialogue.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-confirm-dialogue',
+  templateUrl: './confirm-dialogue.component.html',
+  styleUrls: ['./confirm-dialogue.component.scss']
+})
+export class ConfirmDialogueComponent implements OnInit {
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: any) { }
+
+  ngOnInit(): void {
+  }
+}

--- a/src/app/shared/recording-item/recording-item.component.scss
+++ b/src/app/shared/recording-item/recording-item.component.scss
@@ -1,9 +1,5 @@
 .recording-item {
   margin: 1.25rem 0;
-
-  .highlight {
-    background: var(--hyper-accent-lighter);
-  }
   
   .recording-artist {
     font-size: 1rem;

--- a/src/app/shared/recording-list/recording-list.component.ts
+++ b/src/app/shared/recording-list/recording-list.component.ts
@@ -8,15 +8,18 @@ import { Recording } from '../recording.model';
   styleUrls: ['./recording-list.component.scss'],
 })
 export class RecordingListComponent implements OnInit {
-  @Input() recordings?: Recording[];
+  
+  // External recording against which recordings in this list may be compared to.
   @Input() reference?: Recording;
+  
+  @Input() recordings?: Recording[];
   @Input() error: string = '';
   @Input() isLoading: boolean = false;
   @Input() loadMessage: string = '';
   @Output() selection = new EventEmitter<Recording>();
 
   @ViewChild(MatSelectionList) list!: MatSelectionList;
-  @ViewChildren(MatListOption, { read: ElementRef }) optionEls!: QueryList<ElementRef>
+  @ViewChildren(MatListOption, { read: ElementRef }) optChildrenEls!: QueryList<ElementRef>
 
   constructor() { }
 
@@ -43,10 +46,33 @@ export class RecordingListComponent implements OnInit {
    * Scrolls the topmost selected recording into view.
    */
   showSelected() {
-    const selectedEl = this.optionEls.find(optionEl => {
-      return optionEl.nativeElement.classList.contains('selected-option');
+    const selectedEl = this.optChildrenEls.find(optChildrenEl => {
+      return optChildrenEl.nativeElement.classList.contains('selected-option');
     });
 
     selectedEl?.nativeElement.scrollIntoView();
+  }
+
+  /**
+   * Scrolls to and optionally focusses a given recording item.
+   * @param recording - Object representative of recording data.
+   * @param [isAutofocus = false] - If true, sets focus on the recording item after scroll.
+   */
+  showRecording(recording?: Recording, isAutofocus: boolean = false) {
+    let index;
+    let optionEl;
+
+    if (this.recordings && recording) {
+      index = this.recordings.indexOf(recording);
+
+      if (index >= 0) {
+        optionEl = this.optChildrenEls.get(index);
+        optionEl?.nativeElement.scrollIntoView();
+
+        if (isAutofocus) {
+          this.list.options.get(index)?.focus();
+        }
+      }
+    }
   }
 }

--- a/src/app/shared/recordings.service.ts
+++ b/src/app/shared/recordings.service.ts
@@ -221,6 +221,19 @@ export class RecordingsService {
     });
   }
 
+  hasRecording(collection: Recording[], recording: Recording | undefined): Observable<boolean> {
+    try {
+      if (!recording || isEmpty(recording) || !recording.isrc) {
+        return of(false);
+      }
+      
+      return of(collection.some(item => item.isrc === recording.isrc));
+
+      } catch(error) {
+        return throwError(error);
+      }
+  }
+
   /**
    * Convenience method to turn a given recording into a string of all its property values.
    * @param recording - Object representative of the recording.

--- a/src/app/shared/search-field/search-field.component.ts
+++ b/src/app/shared/search-field/search-field.component.ts
@@ -9,10 +9,10 @@ import { MatInput } from '@angular/material/input';
 export class SearchFieldComponent implements OnInit {
   @Input() placeholder: string = '';
   @Input() query: string = '';
+  @ViewChild('searchInput') searchInput!: MatInput;
 
   // Avoids overlapping the non-standard "search" event
   @Output() lookup = new EventEmitter<string>();
-  @ViewChild('searchInput') searchInput!: MatInput;
 
   constructor() { }
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -2,9 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { RecordingItemComponent } from './recording-item/recording-item.component';
-import { RecordingListComponent } from './recording-list/recording-list.component';
-import { SearchFieldComponent } from './search-field/search-field.component';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
@@ -16,12 +13,19 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { RecordingItemComponent } from './recording-item/recording-item.component';
+import { RecordingListComponent } from './recording-list/recording-list.component';
+import { SearchFieldComponent } from './search-field/search-field.component';
+import { ConfirmDialogueComponent } from './confirm-dialogue/confirm-dialogue.component';
 
 @NgModule({
   declarations: [
     RecordingItemComponent,
     RecordingListComponent,
-    SearchFieldComponent
+    SearchFieldComponent,
+    ConfirmDialogueComponent
   ],
   imports: [
     CommonModule,
@@ -37,7 +41,8 @@ import { MatChipsModule } from '@angular/material/chips';
     MatSnackBarModule,
     MatExpansionModule,
     MatToolbarModule,
-    MatChipsModule
+    MatChipsModule,
+    MatDialogModule
   ],
   exports: [
     RecordingListComponent,

--- a/src/environments/environment.base.ts
+++ b/src/environments/environment.base.ts
@@ -15,11 +15,11 @@ export const environment = {
     keys: [
       {
         name: 'title',
-        weight: 0.8
+        weight: 0.9
       },
       {
         name: 'artist',
-        weight: 0.7
+        weight: 0.8
       },
       {
         name: 'isrc',
@@ -30,5 +30,5 @@ export const environment = {
   },
 
   // Time in milliseconds before notifications are auto-dismissed, if at all.
-  snackbarDelay: 3000
+  snackbarDelay: 4000
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -248,5 +248,5 @@ h1, h2 {
 
 // Increase emphasis on snackbar's action button
 .mat-simple-snackbar-action .mat-button-wrapper {
-  color: var(--hyper-accent-light);
+  color: var(--accent-light);
 }


### PR DESCRIPTION
The assumption is that, while the database probably uses an internal ID independent of the ISRC field (otherwise recordings with a blank ISRC would likely risk the DB's integrity) and thus theoretically allows duplicate ISRCs, the user should be discouraged from doing so. In that sense, a confirmation modal acts as justified friction.